### PR TITLE
feat(rum-bundler): add load more options to facets

### DIFF
--- a/tools/rum-slicer/rum-slicer.css
+++ b/tools/rum-slicer/rum-slicer.css
@@ -366,6 +366,17 @@ fieldset li::after {
   height: 60px;
 }
 
+#facets fieldset div.load-more {
+  grid-column: 2 / span 2;  
+  display: block;
+  padding: 10px 0;
+}
+
+#facets fieldset div.load-more label {
+  cursor: pointer;
+  padding-right: 50px;
+}
+
 .clipboard {
   margin-left: 8px;
   box-sizing: border-box;

--- a/tools/rum-slicer/slicer.js
+++ b/tools/rum-slicer/slicer.js
@@ -565,7 +565,7 @@ function createChartData(bundles, config, endDate) {
   return { labels, datasets, stats };
 }
 
-function updateFacets(facets, cwv, focus, mode, ph) {
+function updateFacets(facets, cwv, focus, mode, ph, show = {}) {
   const numOptions = mode === 'all' ? 20 : 10;
   const filterTags = document.querySelector('.filter-tags');
   filterTags.textContent = '';
@@ -601,8 +601,9 @@ function updateFacets(facets, cwv, focus, mode, ph) {
       optionKeys.sort((a, b) => facet[b] - facet[a]);
       const filterKeys = facetName === 'checkpoint' && mode !== 'all';
       const filteredKeys = filterKeys ? optionKeys.filter((a) => !!(ph[a])) : optionKeys;
+      const nbToShow = show[facetName] || numOptions;
       filteredKeys.forEach((optionKey, i) => {
-        if (i < numOptions) {
+        if (i < nbToShow) {
           const optionValue = facet[optionKey];
           const div = document.createElement('div');
           const input = document.createElement('input');
@@ -708,6 +709,34 @@ function updateFacets(facets, cwv, focus, mode, ph) {
           tsv += `${optionKey}\t${facet[optionKey]}\t\t\t\r\n`;
         }
       });
+
+      if (filteredKeys.length > numOptions) {
+        // add "more" link
+        const div = document.createElement('div');
+        div.className = 'load-more';
+        const more = document.createElement('label');
+        more.textContent = 'more...';
+        more.addEventListener('click', (evt) => {
+          evt.preventDefault();
+          // increase number of keys shown
+          updateFacets(facets, cwv, focus, mode, ph, { [facetName]: (show[facetName] || numOptions) + numOptions });
+        });
+
+        div.append(more);
+
+        const all = document.createElement('label');
+        all.textContent = `all (${filteredKeys.length})`;
+        all.addEventListener('click', (evt) => {
+          evt.preventDefault();
+          // increase number of keys shown
+          updateFacets(facets, cwv, focus,mode, ph, { [facetName]: filteredKeys.length });
+        });
+        div.append(all);
+        const container = document.createElement('div');
+        container.classList.add('more-container');
+        container.append(div);
+        fieldSet.append(container);
+      }
 
       legend.addEventListener('click', () => {
         navigator.clipboard.writeText(tsv);


### PR DESCRIPTION
It is quite often that some items are missing in the facet list. This PR adds a "more..."  and "all (nb)" links at the bottom of each facet (if needed) and allow to expand the list.

See https://rum-bundler-show-more--thinktanked--davidnuescheler.hlx.page/tools/rum-slicer/index.html