### PR TITLE
feat(rum-bundler): add "unfilter" (to replace of metrics=all)

### DIFF
--- a/tools/rum-slicer/rum-slicer.css
+++ b/tools/rum-slicer/rum-slicer.css
@@ -366,13 +366,15 @@ fieldset li::after {
   height: 60px;
 }
 
-#facets fieldset div.load-more {
+#facets fieldset div.load-more,
+#facets fieldset div.unfilter {
   grid-column: 2 / span 2;  
   display: block;
   padding: 10px 0;
 }
 
-#facets fieldset div.load-more label {
+#facets fieldset div.load-more label,
+#facets fieldset div.unfilter label {
   cursor: pointer;
   padding-right: 50px;
 }

--- a/tools/rum-slicer/slicer.js
+++ b/tools/rum-slicer/slicer.js
@@ -740,6 +740,25 @@ function updateFacets(facets, cwv, focus, mode, ph, show = {}) {
         fieldSet.append(container);
       }
 
+      if (filterKeys) {
+        const div = document.createElement('div');
+        div.className = 'unfilter';
+
+        const unfilter = document.createElement('label');
+        unfilter.textContent = `unfilter...`;
+        unfilter.addEventListener('click', (evt) => {
+          evt.preventDefault();
+          // increase number of keys shown
+          updateFacets(facets, cwv, focus, 'all', ph, show);
+        });
+        div.append(unfilter);
+
+        const container = document.createElement('div');
+        container.classList.add('unfilter-container');
+        container.append(div);
+        fieldSet.append(container);
+      }
+
       legend.addEventListener('click', () => {
         navigator.clipboard.writeText(tsv);
         const toast = document.getElementById('copied-toast');


### PR DESCRIPTION
Having to append `metrics=all` to the url is annoying when you want to drill down the checkpoints. This PR adds a `unfilter...` option at the end of the list to switch to unfiltered list mode (and then be able to expand the list)

https://rum-bundler-metrics-all--thinktanked--davidnuescheler.hlx.page/tools/rum-slicer/index.html
